### PR TITLE
linkfix nltk.util.ngrams

### DIFF
--- a/2018/06/03/generating-ngrams.html/index.html
+++ b/2018/06/03/generating-ngrams.html/index.html
@@ -344,7 +344,7 @@ bigrams = zip(*sequences)
         <span>Using NLTK</span>
     </h2>
 </doc-anchor-target>
-<p>Instead of using pure Python functions, we can also get help from some natural language processing libraries such as the <a href="https://www.nltk.org/">Natural Language Toolkit (NLTK)</a>. In particular, nltk has the <code v-pre>ngrams</code> function that returns a generator of n-grams given a tokenized sentence. (See the documentaion of the function <a href="http://www.nltk.org/api/nltk.html#nltk.util.ngrams">here</a>)</p>
+<p>Instead of using pure Python functions, we can also get help from some natural language processing libraries such as the <a href="https://www.nltk.org/">Natural Language Toolkit (NLTK)</a>. In particular, nltk has the <code v-pre>ngrams</code> function that returns a generator of n-grams given a tokenized sentence. (See the documentaion of the function <a href="https://www.nltk.org/api/nltk.util.html#nltk.util.ngrams">here</a>)</p>
 <div class="codeblock-wrapper"><doc-codeblock>
 <pre class="language-python"><code v-pre class="language-python">import re
 from nltk.util import ngrams


### PR DESCRIPTION
The link to the `nltk.ngrams` module on https://albertauyeung.github.io/2018/06/03/generating-ngrams.html/#using-nltk is broken. It should be https://www.nltk.org/api/nltk.util.html#nltk.util.ngrams.