### PR TITLE
Always use light theme

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,4 +1,5 @@
 :root {
+  color-scheme: light;
   --max-width: 1080px;
   --bg: #ffffff;
   --surface: #ffffff;
@@ -11,19 +12,6 @@
   --radius: 8px;
   --serif: "Newsreader", "Iowan Old Style", Georgia, "Times New Roman", serif;
   --sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #111110;
-    --surface: #1a1a18;
-    --text: #ececea;
-    --text-muted: #9c9c98;
-    --border: #2a2a27;
-    --accent-hover: #c2c2bd;
-    --shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 4px 12px rgba(0, 0, 0, 0.25);
-    --shadow-hover: 0 4px 8px rgba(0, 0, 0, 0.4), 0 16px 32px rgba(0, 0, 0, 0.35);
-  }
 }
 
 * { box-sizing: border-box; }


### PR DESCRIPTION
## Summary
- Drop the `@media (prefers-color-scheme: dark)` block so the site no longer auto-switches to dark on devices set to dark mode.
- Add `color-scheme: light` on `:root` so mobile browsers don't auto-darken native UI like scrollbars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)