### PR TITLE
Switch project image cards from 16:9 to square

### DIFF
--- a/style.css
+++ b/style.css
@@ -150,7 +150,7 @@ section h2 {
 .project-image {
   display: block;
   width: 100%;
-  aspect-ratio: 16 / 9;
+  aspect-ratio: 1 / 1;
   object-fit: cover;
   background: var(--border);
   border-bottom: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- Change `.project-image` aspect ratio from `16 / 9` to `1 / 1` so each project card uses a square image box. `object-fit: cover` is already in place to fill it.

## Test plan
- [ ] Open the homepage and verify project cards now show square images at all viewport widths (3-col, 2-col, 1-col).

🤖 Generated with [Claude Code](https://claude.com/claude-code)