### PR TITLE
Fix project images rendering tall instead of square

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,7 +257,7 @@
         <div class="projects">
 
           <a class="project" href="https://ayeung.dev/birds-in-ireland/" target="_blank" rel="noopener">
-            <img class="project-image" src="/images/birds-in-ireland.png" width="1600" height="900" alt="Birds in Ireland — multilingual bird guide for kids" loading="eager" decoding="async" fetchpriority="high" />
+            <img class="project-image" src="/images/birds-in-ireland.png" width="1000" height="1000" alt="Birds in Ireland — multilingual bird guide for kids" loading="eager" decoding="async" fetchpriority="high" />
             <div class="project-body">
               <h3 class="project-title">🐦 Birds in Ireland</h3>
               <p class="project-description">A multilingual bird guide for kids covering 100 birds you can spot in Ireland &mdash; with kid-friendly descriptions, photos, pronunciation guides, and where-to-spot maps in 6 languages.</p>
@@ -266,7 +266,7 @@
           </a>
 
           <a class="project" href="https://scoilscout.ie" target="_blank" rel="noopener">
-            <img class="project-image" src="/images/scoil-scout.png" width="1600" height="900" alt="Scoil Scout — school finder for Irish parents" loading="lazy" decoding="async" />
+            <img class="project-image" src="/images/scoil-scout.png" width="1000" height="1000" alt="Scoil Scout — school finder for Irish parents" loading="lazy" decoding="async" />
             <div class="project-body">
               <h3 class="project-title">🍀 Scoil Scout</h3>
               <p class="project-description">A school finder for Irish parents. Search and filter ~4,000 primary and post-primary schools by county, patronage, language, DEIS status, and more &mdash; all in one place.</p>
@@ -275,7 +275,7 @@
           </a>
 
           <a class="project" href="https://naionrascout.ie" target="_blank" rel="noopener">
-            <img class="project-image" src="/images/naionra-scout.png" width="1600" height="900" alt="Naíonra Scout — Ireland's childcare finder for crèches, preschools, and childminders" loading="lazy" decoding="async" />
+            <img class="project-image" src="/images/naionra-scout.png" width="1000" height="1000" alt="Naíonra Scout — Ireland's childcare finder for crèches, preschools, and childminders" loading="lazy" decoding="async" />
             <div class="project-body">
               <h3 class="project-title">🧸 Na&iacute;onra Scout</h3>
               <p class="project-description">Ireland&rsquo;s childcare finder. Covers every Tusla-registered cr&egrave;che, preschool, childminder, and after-school club &mdash; about 4,000 services across the country.</p>
@@ -284,7 +284,7 @@
           </a>
 
           <a class="project" href="https://ayeung.dev/ireland-by-the-numbers/" target="_blank" rel="noopener">
-            <img class="project-image" src="/images/ireland-by-the-numbers.png" width="1600" height="900" alt="Ireland by the Numbers — Irish open data made readable" loading="lazy" decoding="async" />
+            <img class="project-image" src="/images/ireland-by-the-numbers.png" width="1000" height="1000" alt="Ireland by the Numbers — Irish open data made readable" loading="lazy" decoding="async" />
             <div class="project-body">
               <h3 class="project-title">📊 Ireland by the Numbers</h3>
               <p class="project-description">A small web app that turns Irish open data into something you can read on the bus &mdash; daily facts, story-led explainers, and a chart explorer that talks directly to the CSO PxStat API.</p>
@@ -293,7 +293,7 @@
           </a>
 
           <a class="project" href="https://ayeung.dev/learn-chinese/" target="_blank" rel="noopener">
-            <img class="project-image" src="/images/learn-chinese.png" width="1600" height="900" alt="Learn Chinese — interactive Traditional Chinese app for kids in Cantonese and Mandarin" loading="lazy" decoding="async" />
+            <img class="project-image" src="/images/learn-chinese.png" width="1000" height="1000" alt="Learn Chinese — interactive Traditional Chinese app for kids in Cantonese and Mandarin" loading="lazy" decoding="async" />
             <div class="project-body">
               <h3 class="project-title">🀄 Learn Chinese</h3>
               <p class="project-description">An interactive web app for kids to learn Traditional Chinese through 60 themed lessons, with vocabulary, sentences, short stories, and quizzes &mdash; in both Cantonese and Mandarin.</p>
@@ -302,7 +302,7 @@
           </a>
 
           <a class="project" href="https://ayeung.dev/hex-game/" target="_blank" rel="noopener">
-            <img class="project-image" src="/images/hex-game.png" width="1600" height="900" alt="Hex Game — two-player connection board game" loading="lazy" decoding="async" />
+            <img class="project-image" src="/images/hex-game.png" width="1000" height="1000" alt="Hex Game — two-player connection board game" loading="lazy" decoding="async" />
             <div class="project-body">
               <h3 class="project-title">🎲 Hex Game</h3>
               <p class="project-description">A two-player connection game where each side races to build an unbroken chain of stones across the board. Best played on a tablet or computer.</p>
@@ -311,7 +311,7 @@
           </a>
 
           <a class="project" href="https://ayeung.dev/100-cities-for-kids/" target="_blank" rel="noopener">
-            <img class="project-image" src="/images/100-cities.png" width="1600" height="900" alt="100 Cities for Kids — friendly geography and culture tour for children" loading="lazy" decoding="async" />
+            <img class="project-image" src="/images/100-cities.png" width="1000" height="1000" alt="100 Cities for Kids — friendly geography and culture tour for children" loading="lazy" decoding="async" />
             <div class="project-body">
               <h3 class="project-title">🌍 100 Cities for Kids</h3>
               <p class="project-description">A friendly tour of 100 cities around the world for kids &mdash; covering geography, language, food, culture, famous people, and fun facts about each place.</p>
@@ -320,7 +320,7 @@
           </a>
 
           <a class="project" href="https://hexaflexagon-generator-517239745630.europe-west1.run.app/" target="_blank" rel="noopener">
-            <img class="project-image" src="/images/hexaflexagon.png" width="1600" height="900" alt="Hexaflexagon Generator — printable template builder from three uploaded images" loading="lazy" decoding="async" />
+            <img class="project-image" src="/images/hexaflexagon.png" width="1000" height="1000" alt="Hexaflexagon Generator — printable template builder from three uploaded images" loading="lazy" decoding="async" />
             <div class="project-body">
               <h3 class="project-title">📐 Hexaflexagon Generator</h3>
               <p class="project-description">Upload three images and the app generates a printable template you can cut out and fold into your very own hexaflexagon.</p>

--- a/style.css
+++ b/style.css
@@ -152,6 +152,7 @@ section h2 {
 .project-image {
   display: block;
   width: 100%;
+  height: auto;
   aspect-ratio: 1 / 1;
   object-fit: cover;
   background: var(--border);


### PR DESCRIPTION
## Summary
- The `aspect-ratio: 1 / 1` from #30 was being overridden by the `height="900"` HTML attribute added in #29 (presentation hint sets `height: 900px`, which suppresses `aspect-ratio`).
- Add `height: auto` to `.project-image` so the CSS aspect-ratio applies.
- Update the `<img>` `width`/`height` attributes from `1600`/`900` to `1000`/`1000` so the browser reserves square space pre-load (no layout shift).

## Test plan
- [ ] Reload homepage and verify project image cards render as squares at all viewport widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)