### PR TITLE
Switch analytics from Umami to Trefly

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
   <!-- Performance: resource hints -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="dns-prefetch" href="https://cloud.umami.is" />
+  <link rel="dns-prefetch" href="https://trefly.vercel.app" />
 
   <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400..600;1,6..72,400..600&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
 
@@ -242,7 +242,7 @@
   }
   </script>
 
-  <script defer src="https://cloud.umami.is/script.js" data-website-id="0c30afdf-7301-47b0-8a70-24b0a10719ca"></script>
+  <script defer data-site="RX8JVwKmdCw" src="https://trefly.vercel.app/t.js"></script>
 </head>
 <body>
   <div class="container">


### PR DESCRIPTION
## Summary
- Replaces the Umami `<script>` tag with the self-hosted Trefly snippet (`data-site="RX8JVwKmdCw"`, `src="https://trefly.vercel.app/t.js"`)
- Updates the `dns-prefetch` hint to point at `trefly.vercel.app`

## Test plan
- [ ] After deploy, visit homepage and confirm a pageview lands in the Trefly dashboard
- [ ] Confirm no console errors and no requests to `cloud.umami.is`

🤖 Generated with [Claude Code](https://claude.com/claude-code)